### PR TITLE
Improve vendor setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It helps you bootstrap a development environment with optional vendor apps and a
 
 1. Clone this repository.
 2. Optionally edit `vendor-repos.txt` to list additional apps you want to clone.
-3. Run `./setup.sh` to create the directory structure, clone vendor apps and generate `codex.json`.
+3. Run `./setup.sh` to clone the vendor apps and generate `codex.json`.
 4. Review `init_codex_prompt.md` for the initial prompt used by Codex.
 
 ## Repository Layout
@@ -22,3 +22,10 @@ setup.sh            # Automated initialization script
 ```
 
 See the files in `instructions/` for framework-specific notes.
+
+## `setup.sh`
+
+Run this script after cloning the template. It reads `vendor-repos.txt`, clones
+any repositories listed there into `vendor/` and then creates `codex.json` with
+entries for `apps/` plus every cloned vendor directory. Re-run the script
+whenever you modify `vendor-repos.txt`.

--- a/codex.json
+++ b/codex.json
@@ -1,7 +1,5 @@
 {
   "sources": [
-    "apps/",
-    "vendor/frappe/",
-    "vendor/erpnext/"
+    "apps/"
   ]
 }

--- a/setup.sh
+++ b/setup.sh
@@ -5,28 +5,28 @@ echo "🔧 Initialisiere App-Entwicklungsumgebung..."
 
 # Repos klonen
 mkdir -p vendor
-cd vendor
 
-if [ -f ../vendor-repos.txt ]; then
+if [ -f vendor-repos.txt ]; then
     while read -r repo; do
+        # leere Zeilen ignorieren
+        [ -z "$repo" ] && continue
         name=$(basename "$repo" .git)
-        if [ -n "$repo" ] && [ ! -d "$name" ]; then
-            git clone "$repo"
+        target="vendor/$name"
+        if [ ! -d "$target" ]; then
+            git clone "$repo" "$target"
         fi
-    done < ../vendor-repos.txt
+    done < vendor-repos.txt
 fi
 
-cd ..
-
 # codex.json erzeugen
-cat > codex.json <<'JSON'
-{
-  "sources": [
-    "apps/",
-    "vendor/frappe/",
-    "vendor/erpnext/"
-  ]
-}
-JSON
+sources=("apps/")
+for dir in vendor/*; do
+    [ -d "$dir" ] || continue
+    sources+=("$dir/")
+done
+
+printf '%s\n' "${sources[@]}" \
+    | jq -R . \
+    | jq -s '{sources: .}' > codex.json
 
 echo "✅ Setup abgeschlossen."


### PR DESCRIPTION
## Summary
- generalize `setup.sh` to read `vendor-repos.txt` and generate `codex.json`
- document how to run `setup.sh` in the README
- simplify default `codex.json`

## Testing
- `./setup.sh > /tmp/setup.log`

------
https://chatgpt.com/codex/tasks/task_b_68571e736e10832195118025617f04ce