### PR TITLE
Switch vendor cloning to git submodules

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@ set -e
 
 echo "🔧 Initialisiere App-Entwicklungsumgebung..."
 
-# Repos klonen
+# Repos als Submodule klonen
 mkdir -p vendor
 
 if [ -f vendor-repos.txt ]; then
@@ -13,7 +13,8 @@ if [ -f vendor-repos.txt ]; then
         name=$(basename "$repo" .git)
         target="vendor/$name"
         if [ ! -d "$target" ]; then
-            git clone "$repo" "$target"
+            git submodule add "$repo" "$target"
+            git submodule update --init --recursive "$target"
         fi
     done < vendor-repos.txt
 fi


### PR DESCRIPTION
## Summary
- clone vendor apps as git submodules when missing
- update comments to reflect submodule approach

## Testing
- `shellcheck setup.sh`

------
https://chatgpt.com/codex/tasks/task_b_6857ae9deb0c83219cc74bccbb4a2887