### PR TITLE
Improve Frappe and ERPNext instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ setup.sh            # Automated initialization script
 
 More information is available in the `instructions/` folder:
 
-- [`instructions/frappe.md`](instructions/frappe.md) – notes on creating new
-  Frappe apps and useful links to the documentation.
-- [`instructions/erpnext.md`](instructions/erpnext.md) – guidelines for working
-  with ERPNext modules and doctypes.
+- [`instructions/frappe.md`](instructions/frappe.md) – details on installing
+  Bench, creating new apps, definieren eines `<appname>_Globals` Doctypes sowie
+  den Einsatz von Hooks, Fixtures und API-Aufrufen.
+- [`instructions/erpnext.md`](instructions/erpnext.md) – Tipps zum Erweitern
+  von ERPNext-Modulen, Registrieren eigener Hooks und Exportieren von
+  Customizations.

--- a/instructions/erpnext.md
+++ b/instructions/erpnext.md
@@ -1,5 +1,9 @@
 # ERPNext Development Notes
 
-- Diese App erweitert ERPNext.
+- Diese App erweitert ERPNext und sollte in einer Bench-Umgebung installiert sein.
 - Lege eigene Module unter `apps/my_custom_app` an und verbinde sie über Hooks.
-- Beachte die ERPNext Doctypes wie `Sales Invoice`, `Customer` usw.
+- Nutze die bestehenden ERPNext-Doctypes wie `Sales Invoice` oder `Customer` als Vorlage für eigene Erweiterungen.
+- Exportiere Customizations mit Fixtures, damit sie versionskontrolliert bleiben.
+- Über `hooks.py` kannst du Events wie `on_submit` abfangen und zusätzliche Logik implementieren.
+- Eigene REST-API-Endpunkte lassen sich über Whitelist-Methoden bereitstellen.
+- Für tiefergehende Anpassungen siehe die ERPNext Dokumentation.

--- a/instructions/frappe.md
+++ b/instructions/frappe.md
@@ -1,25 +1,28 @@
 # Frappe Development Notes
 
 - Standard App Struktur in `apps/`
-- Verwende `bench new-app` zum Erstellen neuer Apps
-- Siehe die Frappe Dokumentation für Details zu DocTypes, Hooks und REST API
+- Verwende `bench new-app` zum Erstellen neuer Apps.
+- Nach dem Anlegen einer App bietet sich ein DocType namens `<appname>_Globals` für globale Einstellungen an.
+- Registriere Events und Scheduler-Tasks über `hooks.py`.
+- Exportiere Custom Fields oder Doctypes mit Fixtures via `bench export-fixtures`.
+- API-Aufrufe können über Whitelist-Funktionen oder die REST API erfolgen.
+- Siehe die Frappe Dokumentation für Details zu DocTypes, Hooks und REST API.
 
 ## Prerequisites
 
-- Python 3.10 oder neuer
+- Empfohlen wird Python 3.10.
 - Node.js und Yarn
 - Redis
 - MariaDB
-- Installiere `bench` entweder mit `pip install frappe-bench` oder durch Klonen des [Bench](https://github.com/frappe/bench) Repositorys
+- Installiere Bench mit `pip install frappe-bench` oder klone das [Bench](https://github.com/frappe/bench) Repository.
 
 ### Optionale Umgebungseinrichtung
 
-- Eine virtuelle Umgebung vor der Installation anlegen und aktivieren
-- Mit `bench init <verzeichnis>` ein Bench-Verzeichnis erstellen
+- Eine virtuelle Umgebung vor der Installation anlegen und aktivieren.
+- Mit `bench init <verzeichnis>` ein Bench-Verzeichnis erstellen.
 
 ### Frappe auf den neuesten Stable-Tag aktualisieren
 
-1. Wechsle in dein Bench-Verzeichnis
-2. Führe `bench switch-to-branch version-<x.x.x> frappe --upgrade` aus
-3. Danach `bench update --patch` ausführen
-
+1. Wechsle in dein Bench-Verzeichnis.
+2. Führe `bench switch-to-branch version-<x.x.x> frappe --upgrade` aus.
+3. Danach `bench update --patch` ausführen.


### PR DESCRIPTION
## Summary
- expand Frappe notes with Python version and bench install steps
- outline creating an `<appname>_Globals` Doctype, hooks, fixtures and API usage
- add ERPNext customization tips
- reference these instructions from the README

## Testing
- `npm --version`
- `python3 --version`


------
https://chatgpt.com/codex/tasks/task_b_6857b4f6612c83218a3a74fde34cd54d