### PR TITLE
Improve setup script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,14 @@ vendor apps and prepares a basic `codex.json` index for use with Codex.
 ## Quickstart
 
 1. Clone this repository.
-2. Edit `vendor-repos.txt` to list the Frappe/ERPNext apps you want cloned.
-3. Run `./setup.sh` from the repository root. It clones the apps listed in
-   `vendor-repos.txt` and generates `codex.json`.
+2. Run `git submodule update --init --recursive` to fetch Frappe and ERPNext.
+3. Execute `./setup.sh` from the repository root to generate `codex.json`.
 4. Review `init_codex_prompt.md` for the initial prompt used by Codex.
 
 ## Adding Vendor Apps
 
-Each line in `vendor-repos.txt` should contain the HTTPS URL of a Frappe or
-ERPNext app repository. Re-run `./setup.sh` whenever you change this file to
-fetch the new apps.
+Use `git submodule add <repo> vendor/<name>` to include additional Frappe or
+ERPNext apps. After adding a submodule, run `./setup.sh` to update `codex.json`.
 
 ## Repository Layout
 

--- a/setup.sh
+++ b/setup.sh
@@ -6,18 +6,14 @@ echo "🔧 Initialisiere App-Entwicklungsumgebung..."
 # Repos als Submodule klonen
 mkdir -p vendor
 
-if [ -f vendor-repos.txt ]; then
-    while read -r repo; do
-        # leere Zeilen ignorieren
-        [ -z "$repo" ] && continue
-        name=$(basename "$repo" .git)
-        target="vendor/$name"
-        if [ ! -d "$target" ]; then
-            git submodule add "$repo" "$target"
-            git submodule update --init --recursive "$target"
-        fi
-    done < vendor-repos.txt
+# ensure bench command is available
+if ! command -v bench >/dev/null 2>&1; then
+    echo "ℹ️ 'bench' command not found. Installing frappe-bench..."
+    pip install frappe-bench
 fi
+
+# initialize submodules
+git submodule update --init --recursive
 
 # codex.json erzeugen
 sources=("apps/")
@@ -30,4 +26,10 @@ printf '%s\n' "${sources[@]}" \
     | jq -R . \
     | jq -s '{sources: .}' > codex.json
 
+guide="instructions/frappe.md"
+if [ -f instructions/frappe_dev.md ]; then
+    guide="instructions/frappe_dev.md"
+fi
+
 echo "✅ Setup abgeschlossen."
+echo "➡️  See $guide for next steps."


### PR DESCRIPTION
## Summary
- check for `bench` command in setup script and install it if missing
- initialize git submodules automatically and print next-step instructions
- update README to describe using git submodules instead of `vendor-repos.txt`

## Testing
- `bash -n setup.sh`
- `./setup.sh`

------
https://chatgpt.com/codex/tasks/task_b_6857b4f9f98083218001a7341b26477a