### PR TITLE
Add vendor repo cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ vendor apps and prepares a basic `codex.json` index for use with Codex.
 1. Clone this repository.
 2. Edit `vendor-repos.txt` to list the Frappe/ERPNext apps you want cloned.
 3. Run `./setup.sh` from the repository root. It clones the apps listed in
-   `vendor-repos.txt` and generates `codex.json` referencing `apps/`,
-   `vendor/frappe/`, `vendor/bench/` and `instructions/`.
+   `vendor-repos.txt` and generates `codex.json` referencing `apps/`, every
+   directory under `vendor/` and `instructions/`.
 4. Review `init_codex_prompt.md` for the initial prompt used by Codex.
 
 ## Adding Vendor Apps

--- a/setup.sh
+++ b/setup.sh
@@ -6,22 +6,38 @@ echo "🔧 Initialisiere App-Entwicklungsumgebung..."
 # Repos als Submodule klonen
 mkdir -p vendor
 
+# vendor repos aus vendor-repos.txt hinzufügen
+if [ -f vendor-repos.txt ]; then
+    while IFS= read -r line; do
+        repo=$(echo "$line" | sed 's/#.*//' | xargs)
+        [ -z "$repo" ] && continue
+        name=$(basename "$repo" .git)
+        target="vendor/$name"
+        if [ -d "$target" ]; then
+            echo "ℹ️  $target bereits vorhanden, überspringe."
+        else
+            git submodule add "$repo" "$target"
+        fi
+        git submodule update --init --recursive "$target"
+    done < vendor-repos.txt
+fi
+
 # ensure bench command is available
 if ! command -v bench >/dev/null 2>&1; then
     echo "ℹ️ 'bench' command not found. Installing frappe-bench..."
     pip install frappe-bench
 fi
 
-# initialize submodules
+# vorhandene Submodule initialisieren
 git submodule update --init --recursive
 
 # codex.json erzeugen
-sources=(
-    "apps/"
-    "vendor/frappe/"
-    "vendor/bench/"
-    "instructions/"
-)
+sources=("apps/")
+for dir in vendor/*; do
+    [ -d "$dir" ] || continue
+    sources+=("$dir/")
+done
+sources+=("instructions/")
 
 printf '%s\n' "${sources[@]}" \
     | jq -R . \


### PR DESCRIPTION
## Summary
- update README to mention new vendor directory discovery
- extend setup.sh to clone repos from vendor-repos.txt and update codex.json

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6857b74122fc8321a4cbdfc16a6190a3