### PR TITLE
Consolidate test instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ setup.sh            # Automated initialization script
 
 ## Running Tests
 
-Install the dependencies listed in `requirements.txt` and execute the test suite
-with `pytest`:
+Install the dependencies listed in `requirements.txt` and then execute the test suite with `pytest -q`:
 
 ```bash
 pip install -r requirements.txt
-pytest
+pytest -q
 ```
+
+The included sample test file is located in `tests/basic_integration_test.py`.
 
 ## Further References
 
@@ -48,13 +49,3 @@ More information is available in the `instructions/` folder:
   Frappe apps and useful links to the documentation.
 - [`instructions/erpnext.md`](instructions/erpnext.md) – guidelines for working
   with ERPNext modules and doctypes.
-
-## Running Tests
-
-This repository uses [pytest](https://pytest.org) for tests. To run the test suite:
-
-```bash
-pytest -q
-```
-
-The included sample test file is located in `tests/basic_integration_test.py`.


### PR DESCRIPTION
## Summary
- simplify README test instructions
- keep sample test reference

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6857b74250f48321a0b090ca16efda53