### PR TITLE
Improve docs and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Initialize environment
+        run: ./setup.sh
+
+      - name: Run tests
+        run: pytest -q
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 
 # Frappe App Template
 
-This repository is a starting point for developing custom **Frappe**
-applications. ERPNext can be added manually if required. It bootstraps a local development environment, clones optional
+## TL;DR – Using Codex
+
+1. **Clone this repo** or fork it for your own project.
+2. **Add required vendor apps** to `vendor-repos.txt`.
+3. **Run `./setup.sh`** to clone the listed repositories and generate `codex.json`.
+4. **Start Codex** with the prompt in `init_codex_prompt.md`.
+5. The `CI` workflow runs the same setup and tests automatically.
+
+This repository is a starting point for developing custom **Frappe** applications. ERPNext can be added manually if required. It bootstraps a local development environment, clones optional
 vendor apps and prepares a basic `codex.json` index for use with Codex.
 
 ## Quickstart

--- a/instructions/README.md
+++ b/instructions/README.md
@@ -1,8 +1,12 @@
 # Development Instructions
 
-This directory contains short notes for development with the different frameworks used in this template.
+This directory contains notes for developing apps with this template.
+
+1. List additional vendor repositories in `vendor-repos.txt`.
+2. Run `../setup.sh` to clone them and update `codex.json`.
+3. The `CI` workflow executes the same script on every push or via manual trigger.
+
+Refer to the following guides for framework-specific tips:
 
 - [Frappe Notes](./frappe.md)
 - [ERPNext Notes](./erpnext.md)
-
-Refer to these files when setting up or customizing your application.

--- a/instructions/erpnext.md
+++ b/instructions/erpnext.md
@@ -1,9 +1,11 @@
 # ERPNext Development Notes
 
-- Diese App erweitert ERPNext und sollte in einer Bench-Umgebung installiert sein.
-- Lege eigene Module unter `apps/my_custom_app` an und verbinde sie über Hooks.
-- Nutze die bestehenden ERPNext-Doctypes wie `Sales Invoice` oder `Customer` als Vorlage für eigene Erweiterungen.
-- Exportiere Customizations mit Fixtures, damit sie versionskontrolliert bleiben.
-- Über `hooks.py` kannst du Events wie `on_submit` abfangen und zusätzliche Logik implementieren.
-- Eigene REST-API-Endpunkte lassen sich über Whitelist-Methoden bereitstellen.
-- Für tiefergehende Anpassungen siehe die ERPNext Dokumentation.
+* Diese App erweitert ERPNext und sollte in einer Bench-Umgebung installiert sein.
+* Lege eigene Module unter `apps/my_custom_app` an und verbinde sie über Hooks.
+* Nutze die bestehenden ERPNext-Doctypes wie `Sales Invoice` oder `Customer` als Vorlage für eigene Erweiterungen.
+* Exportiere Customizations mit Fixtures, damit sie versionskontrolliert bleiben.
+* Über `hooks.py` kannst du Events wie `on_submit` abfangen und zusätzliche Logik implementieren.
+* Eigene REST-API-Endpunkte lassen sich über Whitelist-Methoden bereitstellen.
+* Für tiefergehende Anpassungen siehe die ERPNext-Dokumentation.
+
+Um ERPNext hinzuzufügen, trage `https://github.com/frappe/erpnext` in `vendor-repos.txt` ein und führe `../setup.sh` aus.

--- a/instructions/frappe.md
+++ b/instructions/frappe.md
@@ -1,12 +1,14 @@
 # Frappe Development Notes
 
-- Standard App Struktur in `apps/`
-- Verwende `bench new-app` zum Erstellen neuer Apps.
-- Nach dem Anlegen einer App bietet sich ein DocType namens `<appname>_Globals` für globale Einstellungen an.
-- Registriere Events und Scheduler-Tasks über `hooks.py`.
-- Exportiere Custom Fields oder Doctypes mit Fixtures via `bench export-fixtures`.
-- API-Aufrufe können über Whitelist-Funktionen oder die REST API erfolgen.
-- Siehe die Frappe Dokumentation für Details zu DocTypes, Hooks und REST API.
+* Standard-App-Struktur in `apps/`.
+* Verwende `bench new-app` zum Erstellen neuer Apps.
+* Lege einen DocType `<appname>_Globals` für globale Einstellungen an.
+* Registriere Events und Scheduler-Tasks über `hooks.py`.
+* Exportiere Custom Fields oder Doctypes mit Fixtures via `bench export-fixtures`.
+* API-Aufrufe erfolgen über Whitelist-Methoden oder die REST API.
+* Weitere Details findest du in der offiziellen Frappe-Dokumentation.
+
+Um weitere Frappe-Apps einzubinden, ergänze `vendor-repos.txt` und rufe `../setup.sh` auf.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- document quick Codex usage in a TL;DR section
- clarify development instructions and vendor setup
- update framework notes
- add GitHub Actions workflow to run setup and tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6857b8818d68832192fc8e9f13dc8448