### PR TITLE
Add sample data folder with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ This repository is a starting point for developing custom **Frappe**
 applications. ERPNext can be added manually if required. It bootstraps a local development environment, clones optional
 vendor apps and prepares a basic `codex.json` index for use with Codex.
 
+## TL;DR
+
+- Run `./setup.sh` to pull vendor apps and generate `codex.json`.
+- Place any example API payloads or external integration docs under `sample_data/`.
+- See also [TLDR.md](TLDR.md) for a brief checklist.
+
 ## Quickstart
 
 1. Clone this repository.
@@ -15,6 +21,7 @@ vendor apps and prepares a basic `codex.json` index for use with Codex.
    `vendor-repos.txt` and rerun `./setup.sh`.
 4. Review `init_codex_prompt.md` for the initial prompt used by Codex.
 5. See [`prompts.md`](prompts.md) for instructions on adding more templates.
+6. Legt Beispiel-JSONs oder Schnittstellendokumente im Verzeichnis `sample_data/` ab, falls eure App externe Dienste nutzt.
 
 ## Adding Vendor Apps
 
@@ -37,6 +44,7 @@ instructions/       # Development guides
 codex.json          # Index of sources for Codex
 codex_prompt.md     # Main prompt for Codex
 setup.sh            # Automated initialization script
+sample_data/        # Example payloads and API docs for external services
 ```
 
 ## Running Tests

--- a/TLDR.md
+++ b/TLDR.md
@@ -1,0 +1,5 @@
+# TL;DR
+
+1. `./setup.sh` klont Frappe, Bench und erzeugt `codex.json`.
+2. Beispiel- und Schnittstellendaten legst du in `sample_data/` ab.
+3. Weitere Hinweise findest du im [README](README.md) und im Ordner `instructions/`.

--- a/codex.json
+++ b/codex.json
@@ -3,6 +3,7 @@
     "apps/",
     "vendor/frappe/",
     "vendor/bench/",
-    "instructions/"
+    "instructions/",
+    "sample_data/"
   ]
 }

--- a/instructions/README.md
+++ b/instructions/README.md
@@ -6,3 +6,7 @@ This directory contains short notes for development with the different framework
 - [ERPNext Notes](./erpnext.md)
 
 Refer to these files when setting up or customizing your application.
+
+Sample payloads or third-party interface docs can be kept in the
+`sample_data/` folder at the repository root.
+

--- a/instructions/erpnext.md
+++ b/instructions/erpnext.md
@@ -7,3 +7,4 @@
 - Über `hooks.py` kannst du Events wie `on_submit` abfangen und zusätzliche Logik implementieren.
 - Eigene REST-API-Endpunkte lassen sich über Whitelist-Methoden bereitstellen.
 - Für tiefergehende Anpassungen siehe die ERPNext Dokumentation.
+- Lege Beispiel-JSONs externer Schnittstellen in `sample_data/` ab, um sie versioniert vorzuhalten.

--- a/instructions/frappe.md
+++ b/instructions/frappe.md
@@ -7,6 +7,7 @@
 - Exportiere Custom Fields oder Doctypes mit Fixtures via `bench export-fixtures`.
 - API-Aufrufe können über Whitelist-Funktionen oder die REST API erfolgen.
 - Siehe die Frappe Dokumentation für Details zu DocTypes, Hooks und REST API.
+- Beispielantworten externer Dienste kannst du in `sample_data/` ablegen.
 
 ## Prerequisites
 

--- a/prompts.md
+++ b/prompts.md
@@ -95,3 +95,19 @@ Repos:
 ```
 
 Codex ergänzt `vendor-repos.txt`, führt `setup.sh` erneut aus und holt die neuen Repositories nach `vendor/`.
+
+---
+
+## Prompt 10: Beispielordner anlegen
+
+"Lege unter `sample_data/` einen Ordner fuer Beispiel-JSONs an und fuege eine Datei `example.json` mit einer Musterantwort hinzu."
+
+Codex erstellt das Verzeichnis und die Beispiel-Datei.
+
+---
+
+## Prompt 11: Weitere Beispiele hinzufuegen
+
+"Ergaenze `sample_data/` um weitere Dateien oder Dokumentationen fuer externe Schnittstellen."
+
+Codex legt zusaetzliche Dateien ab und ergaenzt die README bei Bedarf.

--- a/sample_data/README.md
+++ b/sample_data/README.md
@@ -1,0 +1,5 @@
+# Sample Data
+
+This directory collects example payloads or documentation for third-party services.
+Store JSON responses, API call examples, or interface notes here so that Codex has
+context when your app communicates with external systems.

--- a/sample_data/example.json
+++ b/sample_data/example.json
@@ -1,0 +1,4 @@
+{
+  "example": "Hello from external service",
+  "status": "success"
+}


### PR DESCRIPTION
## Summary
- add `sample_data` folder for JSON and interface examples
- document the new folder in README and TLDR sections
- mention sample data location in development instructions
- extend prompt list with examples about sample data
- include new folder in `codex.json` source list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857b972623c8321a4552200fb4ca9ff