### PR TITLE
Add sample_data directory for external API examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 3. **Run `./setup.sh`** to clone the listed repositories and generate `codex.json`.
 4. **Start Codex** with the prompt in `init_codex_prompt.md`.
 5. The `CI` workflow runs the same setup and tests automatically.
+6. **Optional sample data** for external integrations lives in `sample_data/`.
 
-This repository is a starting point for developing custom **Frappe** applications. ERPNext can be added manually if required. It bootstraps a local development environment, clones optional
-vendor apps and prepares a basic `codex.json` index for use with Codex.
+This repository is a starting point for developing custom **Frappe** applications. ERPNext can be added manually if required. It bootstraps a local development environment, clones optional vendor apps and prepares a basic `codex.json` index for use with Codex. Sample payloads or interface documentation can be stored in the `sample_data/` folder.
 
 ## Quickstart
 
@@ -22,6 +22,8 @@ vendor apps and prepares a basic `codex.json` index for use with Codex.
    `vendor-repos.txt` and rerun `./setup.sh`.
 4. Review `init_codex_prompt.md` for the initial prompt used by Codex.
 5. See [`prompts.md`](prompts.md) for instructions on adding more templates.
+6. Place any example payloads or external API docs under `sample_data/` for
+   reference.
 
 ## Adding Vendor Apps
 
@@ -44,6 +46,7 @@ instructions/       # Development guides
 codex.json          # Index of sources for Codex
 codex_prompt.md     # Main prompt for Codex
 setup.sh            # Automated initialization script
+sample_data/        # Example payloads and external API documentation
 ```
 
 ## Running Tests

--- a/codex.json
+++ b/codex.json
@@ -3,6 +3,7 @@
     "apps/",
     "vendor/frappe/",
     "vendor/bench/",
-    "instructions/"
+    "instructions/",
+    "sample_data/"
   ]
 }

--- a/instructions/README.md
+++ b/instructions/README.md
@@ -5,6 +5,7 @@ This directory contains notes for developing apps with this template.
 1. List additional vendor repositories in `vendor-repos.txt`.
 2. Run `../setup.sh` to clone them and update `codex.json`.
 3. The `CI` workflow executes the same script on every push or via manual trigger.
+4. Store JSON example files and API docs in `../sample_data` when needed.
 
 Refer to the following guides for framework-specific tips:
 

--- a/sample_data/README.md
+++ b/sample_data/README.md
@@ -1,0 +1,5 @@
+# Sample Data
+
+Place JSON example files, API interface documentation or other
+reference data here. These files help document expected payloads
+or external service interactions.

--- a/sample_data/example_payload.json
+++ b/sample_data/example_payload.json
@@ -1,0 +1,5 @@
+{
+  "name": "Example",
+  "value": 123,
+  "active": true
+}


### PR DESCRIPTION
## Summary
- provide sample_data folder for storing example payloads and docs
- document the folder in the TL;DR and README sections
- note the sample data location in development instructions
- include sample_data in codex sources

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857baf8d4f48321b5f0ab007f7d932e