### PR TITLE
Separate docs for humans and Codex

### DIFF
--- a/DEV_INSTRUCTIONS.md
+++ b/DEV_INSTRUCTIONS.md
@@ -1,0 +1,26 @@
+# Developer Instructions for Codex
+
+This repository uses Codex for automated code generation. These guidelines tell Codex how to work with the project.
+
+## Setup
+
+1. Add any vendor repositories to `vendor-repos.txt`.
+2. Run `./setup.sh` to clone vendor apps and regenerate `codex.json`.
+3. The CI workflow executes the same script on every push.
+4. Example payloads or external API docs belong in `sample_data/`.
+
+## Repository Layout
+
+- `apps/` – custom apps created in this project.
+- `vendor/` – Frappe and other vendor apps managed as submodules.
+- `instructions/` – framework notes for Frappe and ERPNext.
+- `sample_data/` – reference payloads and docs.
+
+## Testing
+
+Install dependencies from `requirements.txt` and run `pytest -q`.
+
+```bash
+pip install -r requirements.txt
+pytest -q
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 
 # Frappe App Template
 
+**Important:** This project keeps its documentation in two separate files. This
+`README.md` is written for human developers who want to build on top of the
+template with Codex. Detailed instructions for the Codex automation live in
+`DEV_INSTRUCTIONS.md`.
+
 ## TL;DR – Using Codex
 
 1. **Clone this repo** or fork it for your own project.

--- a/instructions/README.md
+++ b/instructions/README.md
@@ -1,6 +1,7 @@
 # Development Instructions
 
-This directory contains notes for developing apps with this template.
+This directory contains additional notes for Frappe and ERPNext. For the
+automation guidelines used by Codex see `../DEV_INSTRUCTIONS.md`.
 
 1. List additional vendor repositories in `vendor-repos.txt`.
 2. Run `../setup.sh` to clone them and update `codex.json`.


### PR DESCRIPTION
## Summary
- clarify that the repository has two docs
- add `DEV_INSTRUCTIONS.md` with notes for Codex
- point instructions README to the machine doc

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857bc17d8948321a994670a3f0f35e6