### PR TITLE
Add .gitignore with basic Python and Frappe ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python byte-compiled files
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Virtual environments
+env/
+venv/
+ENV/
+.venv
+.env
+
+# Python packaging
+build/
+dist/
+.eggs/
+*.egg-info/
+
+# Bench / Frappe
+node_modules/
+sites/assets/
+sites/*/public/
+
+# Logs
+*.log


### PR DESCRIPTION
## Summary
- add a `.gitignore` file with common ignores for Python projects and Frappe apps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857cf0092ec8321a78dfcae8aaf9dd4