### PR TITLE
Add pinned Frappe/Bench versions

### DIFF
--- a/.github/workflows/update-vendor.yml
+++ b/.github/workflows/update-vendor.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
   push:
     paths:
+      - apps.json
       - vendor-repos.txt
       - template-repos.txt
 
@@ -36,14 +37,14 @@ jobs:
         run: ./setup.sh
 
       - name: Update submodules
-        run: git submodule update --remote --init --recursive
+        run: git submodule update --init --recursive
 
       - name: Commit changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add vendor .gitmodules codex.json vendor-repos.txt
-          git add template-repos.txt
+          git add vendor .gitmodules codex.json apps.json
+          git add vendor-repos.txt template-repos.txt
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/DEV_INSTRUCTIONS.md
+++ b/DEV_INSTRUCTIONS.md
@@ -4,7 +4,8 @@ This repository uses Codex for automated code generation. These guidelines tell 
 
 ## Setup
 
-1. Add framework repositories such as Frappe or ERPNext to `vendor-repos.txt`.
+1. Frappe and Bench are pinned via `apps.json`. Add further framework
+   repositories such as ERPNext or HRMS to `vendor-repos.txt`.
 2. List additional template repositories in `template-repos.txt`. Their
    instructions will be merged into `codex.json` automatically.
 3. The *Update Vendor Apps* workflow clones all repositories from both lists and
@@ -19,7 +20,7 @@ This repository uses Codex for automated code generation. These guidelines tell 
 - `vendor/` – Frappe and other vendor apps managed as submodules.
 - `instructions/` – framework notes for Frappe and ERPNext.
 - `sample_data/` – reference payloads and docs.
-- `vendor-repos.txt` – list of framework repositories.
+- `vendor-repos.txt` – additional framework repositories to clone.
 - `template-repos.txt` – list of additional template repositories.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -9,36 +9,42 @@ template with Codex. Detailed instructions for the Codex automation live in
 ## TL;DR – Using Codex
 
 1. **Clone this repo** or fork it for your own project.
-2. **Add required framework repos** (Frappe/ERPNext/HRMS) to `vendor-repos.txt`.
-3. **Add optional template repos** to `template-repos.txt` when you want to
+2. **Frappe** and **Bench** are included as submodules using the versions
+   specified in `apps.json`.
+3. **Add additional framework repos** (ERPNext/HRMS) to `vendor-repos.txt` when
+   needed.
+4. **Add optional template repos** to `template-repos.txt` when you want to
    include additional instructions.
-4. The *Update Vendor Apps* workflow clones the listed repositories and
+5. The *Update Vendor Apps* workflow clones the listed repositories and
    generates `codex.json`. You can still run `./setup.sh` locally if needed
    (make sure `jq` is installed).
-5. **Start your project** by editing `vendor-repos.txt` and
+6. **Start your project** by editing `vendor-repos.txt` (for extra apps) and
    `template-repos.txt` to include all external repositories you need.
    Run the *Update Vendor Apps* workflow or `./setup.sh` to clone them and
    rebuild `codex.json`.
-6. The `CI` workflow runs the same setup and tests automatically.
-7. **Optional sample data** for external integrations lives in `sample_data/`.
+7. The `CI` workflow runs the same setup and tests automatically.
+8. **Optional sample data** for external integrations lives in `sample_data/`.
 
 This repository is a starting point for developing custom **Frappe** applications. ERPNext can be added manually if required. It bootstraps a local development environment, clones optional vendor apps and prepares a basic `codex.json` index for use with Codex. Sample payloads or interface documentation can be stored in the `sample_data/` folder.
 
 ## Quickstart
 
 1. Clone this repository.
-2. By default `vendor-repos.txt` contains only Frappe. The *Update Vendor Apps*
-   workflow clones these repositories and regenerates `codex.json`. Run
-   `./setup.sh` locally if you want to mirror the process (requires `jq`).
-3. Optional development templates can be listed in `template-repos.txt`.
+2. Default versions for Frappe and Bench are defined in `apps.json` and
+   already checked out as submodules.
+3. `vendor-repos.txt` starts empty. Frappe and Bench are already checked out via
+   `apps.json`. The *Update Vendor Apps* workflow clones any listed repositories
+   and regenerates `codex.json`. Run `./setup.sh` locally if you want to mirror
+   the process (requires `jq`).
+4. Optional development templates can be listed in `template-repos.txt`.
    They will be cloned alongside the framework repos and their instructions are
    added to Codex automatically.
-4. To add ERPNext, append `https://github.com/frappe/erpnext` to
+5. To add ERPNext, append `https://github.com/frappe/erpnext` to
    `vendor-repos.txt` and trigger the workflow or run `./setup.sh` manually
    (requires `jq`).
-5. Review `codex_prompt.md` for the default guidelines Codex follows.
-6. See [`prompts.md`](prompts.md) for instructions on adding more templates.
-7. Place any example payloads or external API docs under `sample_data/` for
+6. Review `codex_prompt.md` for the default guidelines Codex follows.
+7. See [`prompts.md`](prompts.md) for instructions on adding more templates.
+8. Place any example payloads or external API docs under `sample_data/` for
    reference. The directory is indexed in `codex.json` when present.
 
 ## Adding Vendor Apps
@@ -58,8 +64,8 @@ This clones ERPNext into `vendor/` and updates `codex.json`.
 
 Two lists keep track of external sources:
 
-1. `vendor-repos.txt` – reference repositories for the framework itself such as
-   Frappe, ERPNext or HRMS.
+1. `vendor-repos.txt` – additional framework apps such as ERPNext or HRMS.
+   Frappe and Bench are already pinned in `apps.json`.
 2. `template-repos.txt` – additional templates that include their own
    development instructions.
 
@@ -76,8 +82,9 @@ instructions/       # Development guides
 codex.json          # Index of sources for Codex
 codex_prompt.md     # Main prompt for Codex
 setup.sh            # Automated initialization script
-vendor-repos.txt    # Framework repositories like Frappe
+vendor-repos.txt    # Additional framework repositories
 template-repos.txt  # Additional templates with instructions
+apps.json           # Pinned versions for Frappe and Bench
 sample_data/        # Example payloads and external API documentation
 ```
 

--- a/apps.json
+++ b/apps.json
@@ -1,0 +1,10 @@
+[
+  {
+    "url": "https://github.com/frappe/frappe",
+    "tag": "v15.71.0"
+  },
+  {
+    "url": "https://github.com/frappe/bench",
+    "tag": "v5.25.5"
+  }
+]

--- a/instructions/README.md
+++ b/instructions/README.md
@@ -3,7 +3,8 @@
 This directory contains additional notes for Frappe and ERPNext. For the
 automation guidelines used by Codex see `../DEV_INSTRUCTIONS.md`.
 
-1. Add framework repositories (Frappe/ERPNext/HRMS) to `vendor-repos.txt`.
+1. Frappe and Bench are pinned via `apps.json`. Add further framework
+   repositories (ERPNext/HRMS) to `vendor-repos.txt`.
 2. List template repositories that ship extra instructions in
    `template-repos.txt`.
 3. The *Update Vendor Apps* workflow clones all repositories and refreshes

--- a/instructions/erpnext.md
+++ b/instructions/erpnext.md
@@ -8,4 +8,4 @@
 * Eigene REST-API-Endpunkte lassen sich über Whitelist-Methoden bereitstellen.
 * Für tiefergehende Anpassungen siehe die ERPNext-Dokumentation.
 
-Um ERPNext hinzuzufügen, trage `https://github.com/frappe/erpnext` in `vendor-repos.txt` ein und starte das Workflow **Update Vendor Apps** oder führe `../setup.sh` aus.
+Frappe und Bench sind bereits über `apps.json` eingebunden. Um ERPNext hinzuzufügen, trage `https://github.com/frappe/erpnext` in `vendor-repos.txt` ein und starte das Workflow **Update Vendor Apps** oder führe `../setup.sh` aus.

--- a/instructions/frappe.md
+++ b/instructions/frappe.md
@@ -8,8 +8,9 @@
 * API-Aufrufe erfolgen über Whitelist-Methoden oder die REST API.
 * Weitere Details findest du in der offiziellen Frappe-Dokumentation.
 
-Um weitere Frappe-Apps einzubinden, ergänze `vendor-repos.txt` und trigger das
-Workflow **Update Vendor Apps** oder führe `../setup.sh` manuell aus.
+Frappe und Bench sind bereits über `apps.json` eingebunden. Um weitere
+Frappe-Apps einzubinden, ergänze `vendor-repos.txt` und trigger das Workflow
+**Update Vendor Apps** oder führe `../setup.sh` manuell aus.
 
 ## Prerequisites
 

--- a/prompts.md
+++ b/prompts.md
@@ -71,15 +71,15 @@ Codex führt `git submodule update --remote apps/frappe` aus und commitet die Ä
 
 ## Prompt 7: Frappe-only Initialisierung
 
-"Starte das Projekt ausschließlich mit Frappe. Entferne ERPNext aus `vendor-repos.txt`, behalte Frappe und Bench und führe `./setup.sh` aus oder triggere das Workflow **Update Vendor Apps**."
+"Starte das Projekt ausschließlich mit Frappe. Entferne ERPNext aus `vendor-repos.txt`. Frappe und Bench sind bereits über `apps.json` eingebunden. Führe `./setup.sh` aus oder triggere das Workflow **Update Vendor Apps**."
 
-Codex aktualisiert `vendor-repos.txt`, klont nur Frappe und Bench und erzeugt eine neue `codex.json`.
+Codex aktualisiert `vendor-repos.txt`, nutzt die Angaben aus `apps.json` für Frappe und Bench und erzeugt eine neue `codex.json`.
 
 ---
 
 ## Prompt 8: ERPNext nachträglich hinzufügen
 
-"Füge ERPNext jetzt hinzu. Trage `https://github.com/frappe/erpnext` in `vendor-repos.txt` ein und rufe erneut `./setup.sh` auf oder starte das Workflow **Update Vendor Apps**."
+"Füge ERPNext jetzt hinzu. Trage `https://github.com/frappe/erpnext` in `vendor-repos.txt` ein und rufe erneut `./setup.sh` auf oder starte das Workflow **Update Vendor Apps**. Frappe und Bench bleiben über `apps.json` bestehen."
 
 Codex modifiziert `vendor-repos.txt`, klont ERPNext unter `vendor/` und aktualisiert `codex.json`.
 

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,24 @@ echo "🔧 Initialisiere App-Entwicklungsumgebung..."
 # Repos als Submodule klonen
 mkdir -p vendor
 
-# vendor repos aus vendor-repos.txt und template-repos.txt hinzufügen
+# vendor apps aus apps.json initialisieren
+if [ -f apps.json ]; then
+    jq -c '.[]' apps.json | while read -r entry; do
+        repo=$(echo "$entry" | jq -r '.url')
+        tag=$(echo "$entry" | jq -r '.tag')
+        name=$(basename "$repo" .git)
+        target="vendor/$name"
+        if [ -d "$target" ]; then
+            echo "ℹ️  Aktualisiere $target auf $tag"
+            git -C "$target" fetch --tags
+        else
+            git submodule add "$repo" "$target"
+        fi
+        git -C "$target" checkout "$tag"
+    done
+fi
+
+# weitere repos aus vendor-repos.txt und template-repos.txt hinzufügen
 for list in vendor-repos.txt template-repos.txt; do
     [ -f "$list" ] || continue
     while IFS= read -r line; do

--- a/vendor-repos.txt
+++ b/vendor-repos.txt
@@ -1,2 +1,2 @@
-https://github.com/frappe/frappe
-https://github.com/frappe/bench  # bench v5.x (optional)
+# Add additional framework repositories here (e.g. ERPNext).
+# Frappe and Bench are already included via `apps.json`.


### PR DESCRIPTION
## Summary
- pin Frappe and Bench submodules to tagged releases
- create `apps.json` with default versions
- update setup script to read `apps.json`
- mention pinned versions in README
- adjust Update Vendor workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6857d478ab8c8321b3267050232d4e0a