### PR TITLE
Add draw.io build workflow

### DIFF
--- a/.github/workflows/build-drawio-webjar.yml
+++ b/.github/workflows/build-drawio-webjar.yml
@@ -1,0 +1,51 @@
+name: Build Draw.io WebJar
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Build draw.io WebJar
+        run: |
+          git clone https://github.com/jgraph/drawio.git
+          git clone https://github.com/jgraph/drawio-webjar.git
+          cd drawio
+          npm install
+          npm run build
+          cd ../drawio-webjar
+          mvn -B package -DskipTests
+          mkdir -p ../build
+          cp target/*.jar ../build/drawio-webjar.jar
+
+      - name: Build XWiki Application
+        run: |
+          git clone https://github.com/xwiki-contrib/application-drawio.git
+          cd application-drawio
+          mvn -B package -DskipTests
+          mkdir -p ../build
+          cp target/*.xar ../build/
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: drawio-xwiki
+          path: build
+

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ pytest -q
 ```
 
 The included sample test file is located in `tests/basic_integration_test.py`.
+## Draw.io Build Workflow
+
+The workflow `build-drawio-webjar.yml` compiles the Draw.io WebJar and builds the XWiki extension. Trigger it manually from the *Actions* tab to generate a WebJar and XAR artifact.
+
 
 ## Further References
 


### PR DESCRIPTION
## Summary
- add workflow to compile a Draw.io WebJar and XWiki extension
- document new workflow in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6857f640bca0832197df3844fab549cc