### PR TITLE
Add jq presence check in setup scripts

### DIFF
--- a/erpnext_app_template/setup.sh
+++ b/erpnext_app_template/setup.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# ensure jq command is available
+if ! command -v jq >/dev/null 2>&1; then
+    echo "❌ 'jq' command not found. Please install jq and re-run this script." >&2
+    exit 1
+fi
+
 echo "🔧 Initialisiere App-Entwicklungsumgebung..."
 
 # vorhandene Submodule initialisieren

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# ensure jq command is available
+if ! command -v jq >/dev/null 2>&1; then
+    echo "❌ 'jq' command not found. Please install jq and re-run this script." >&2
+    exit 1
+fi
+
 echo "🔧 Initialisiere App-Entwicklungsumgebung..."
 
 # Repos als Submodule klonen


### PR DESCRIPTION
## Summary
- ensure `jq` is installed before running setup scripts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `pip install -r erpnext_app_template/requirements.txt`
- `pytest -q` in `erpnext_app_template`

------
https://chatgpt.com/codex/tasks/task_b_6857f97f084083218426331ffd39ac5d