### PR TITLE
Add placeholder app docs and DocType

### DIFF
--- a/apps/my_custom_app/README.md
+++ b/apps/my_custom_app/README.md
@@ -1,0 +1,3 @@
+# My Custom App
+
+This folder contains a minimal Frappe application used as an example within this template project. The app does not implement any business logic yet but provides a placeholder DocType for storing global settings.

--- a/apps/my_custom_app/my_custom_app/doctype/my_custom_app_globals/my_custom_app_globals.json
+++ b/apps/my_custom_app/my_custom_app/doctype/my_custom_app_globals/my_custom_app_globals.json
@@ -1,0 +1,7 @@
+{
+  "doctype": "DocType",
+  "name": "My Custom App Globals",
+  "module": "My Custom App",
+  "custom": 1,
+  "fields": []
+}

--- a/erpnext_app_template/apps/my_custom_app/README.md
+++ b/erpnext_app_template/apps/my_custom_app/README.md
@@ -1,0 +1,3 @@
+# My Custom App
+
+This directory mirrors the structure of the main template and serves as a placeholder ERPNext module. It contains a basic DocType for global settings but no additional functionality yet.

--- a/erpnext_app_template/apps/my_custom_app/my_custom_app/doctype/my_custom_app_globals/my_custom_app_globals.json
+++ b/erpnext_app_template/apps/my_custom_app/my_custom_app/doctype/my_custom_app_globals/my_custom_app_globals.json
@@ -1,0 +1,7 @@
+{
+  "doctype": "DocType",
+  "name": "My Custom App Globals",
+  "module": "My Custom App",
+  "custom": 1,
+  "fields": []
+}


### PR DESCRIPTION
## Summary
- document the example Frappe app
- add minimal DocType skeleton for `My Custom App`
- mirror the same structure in the ERPNext template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857f97ff2fc83219329a182751864f4