### PR TITLE
Add tests for setup script

### DIFF
--- a/erpnext_app_template/tests/test_setup_script.py
+++ b/erpnext_app_template/tests/test_setup_script.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def run_setup(script: Path, tmpdir: Path):
+    subprocess.run(["git", "init"], cwd=tmpdir, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (tmpdir / "apps").mkdir()
+    (tmpdir / "vendor" / "myapp" / "instructions").mkdir(parents=True)
+    (tmpdir / "instructions").mkdir()
+    (tmpdir / "sample_data").mkdir()
+    subprocess.run(["bash", str(script)], cwd=tmpdir, check=True)
+    with open(tmpdir / "codex.json") as f:
+        data = json.load(f)
+    return data["sources"]
+
+
+def test_setup_creates_expected_codex_json(tmp_path):
+    script = Path(__file__).resolve().parent.parent / "setup.sh"
+    sources = run_setup(script, tmp_path)
+    assert sources == [
+        "apps/",
+        "vendor/myapp/",
+        "vendor/myapp/instructions/",
+        "instructions/",
+        "sample_data/",
+    ]
+

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def run_setup(script: Path, tmpdir: Path):
+    subprocess.run(["git", "init"], cwd=tmpdir, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (tmpdir / "apps").mkdir()
+    (tmpdir / "vendor" / "myapp" / "instructions").mkdir(parents=True)
+    (tmpdir / "instructions").mkdir()
+    (tmpdir / "sample_data").mkdir()
+    subprocess.run(["bash", str(script)], cwd=tmpdir, check=True)
+    with open(tmpdir / "codex.json") as f:
+        data = json.load(f)
+    return data["sources"]
+
+
+def test_setup_creates_expected_codex_json(tmp_path):
+    script = Path(__file__).resolve().parent.parent / "setup.sh"
+    sources = run_setup(script, tmp_path)
+    assert sources == [
+        "apps/",
+        "vendor/myapp/",
+        "vendor/myapp/instructions/",
+        "instructions/",
+        "sample_data/",
+    ]
+


### PR DESCRIPTION
## Summary
- ensure setup.sh generates codex.json in a clean repo
- mirror the same test for the ERPNext template

## Testing
- `pip install -r requirements.txt`
- `pip install -r erpnext_app_template/requirements.txt`
- `pytest -q`
- `cd erpnext_app_template && pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857f98013848321bbf78b5f77e9dc5c