### PR TITLE
Handle vendor apps via apps.json in templates

### DIFF
--- a/.github/workflows/update-vendor.yml
+++ b/.github/workflows/update-vendor.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - vendor-repos.txt
       - template-repos.txt
+      - apps.json
+      - '**/apps.json'
 
 permissions:
   contents: write
@@ -40,7 +42,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add vendor .gitmodules codex.json vendor-repos.txt apps.json
-          git add template-repos.txt
+          git add template-repos.txt */apps.json
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/DEV_INSTRUCTIONS.md
+++ b/DEV_INSTRUCTIONS.md
@@ -7,7 +7,8 @@ This repository uses Codex for automated code generation. These guidelines tell 
 1. Versions for Frappe and Bench are defined in `apps.json`. Add additional
    framework repositories to `vendor-repos.txt`.
 2. List additional template repositories in `template-repos.txt`. Their
-    instructions and any `vendor-repos.txt` files are merged automatically.
+    instructions, any `vendor-repos.txt` files and potential `apps.json`
+    definitions are merged automatically.
 3. The *Update Vendor Apps* workflow clones all repositories from the merged
     lists and regenerates `codex.json`. Run `./setup.sh` locally for the same
     effect (requires `jq`).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ template with Codex. Detailed instructions for the Codex automation live in
 1. **Clone this repo** or fork it for your own project and work in a local copy.
 2. **Adjust vendor versions** in `apps.json` if you need different tags for
    Frappe or Bench. Add further frameworks to `vendor-repos.txt`.
-3. **Add optional template repos** to `template-repos.txt` when you want to include additional instructions.
+3. **Add optional template repos** to `template-repos.txt` when you want to include additional instructions. Templates may also ship an `apps.json` that pins their vendor apps.
 4. **Optional sample data** for external integrations lives in `sample_data/`.
 5. **Commit and push to a fresh repository** once your lists are complete.
 
@@ -40,9 +40,9 @@ This repository is a starting point for developing custom **Frappe** application
 3. Optional development templates can be listed in `template-repos.txt`.
     They will be cloned alongside the framework repos and their instructions are
     added to Codex automatically.
-4. Template repositories may ship their own `vendor-repos.txt`. The update
-    workflow collects those files recursively and merges all entries so every
-    required vendor app is cloned automatically.
+4. Template repositories may ship their own `apps.json` and `vendor-repos.txt`.
+    The update workflow processes these files recursively so every required
+    vendor app is cloned in the specified version automatically.
 5. Review `codex_prompt.md` for the default guidelines Codex follows.
 6. See [`prompts.md`](prompts.md) for instructions on adding more templates.
 7. Place any example payloads or external API docs under `sample_data/` for
@@ -61,21 +61,24 @@ cloned automatically.
 Three files keep track of external sources:
 
 1. `apps.json` – default vendor apps like Frappe and Bench with their tag
-   versions.
+   versions. Template repositories may ship their own `apps.json` files to pin
+   additional vendor projects.
 2. `vendor-repos.txt` – additional framework repositories (e.g. ERPNext).
 3. `template-repos.txt` – optional templates that include their own development
    instructions.
 
-The update workflow clones both lists and adds any `instructions/` directories
-from the templates to `codex.json`. Follow those instructions together with this
-document when developing your app.
+The update workflow clones repositories from these lists and also processes any
+`apps.json` found inside the templates. All vendor apps are checked out at the
+specified tag and `instructions/` folders are merged into `codex.json`. Follow
+those instructions together with this document when developing your app.
 
 ## Using `apps.json`
 
 The file `apps.json` defines the default versions for the core Frappe stack.
 Each entry specifies a repository URL and the tag that will be checked out
 by the update workflow. Adjust these tags when you need a newer or older
-release of Frappe or Bench:
+release of Frappe or Bench. Any template repositories are scanned for their own
+`apps.json` files which are processed in the same way:
 
 ```json
 {

--- a/erpnext_app_template/DEV_INSTRUCTIONS.md
+++ b/erpnext_app_template/DEV_INSTRUCTIONS.md
@@ -6,9 +6,10 @@ This repository acts as a template for ERPNext extensions and is usually combine
 
 1. Include this repository as a submodule of the Frappe template.
 2. Optional template repositories can be added to `template-repos.txt`.
-3. Trigger the **Update Vendor Apps** workflow in the Frappe template (or run `./setup.sh` there) to fetch ERPNext and rebuild `codex.json`.
-4. The CI workflow in this repo executes the same script on each push.
-5. Place reference payloads or API docs in `sample_data/`.
+3. Set the desired ERPNext tag in `apps.json`.
+4. Trigger the **Update Vendor Apps** workflow in the Frappe template (or run `./setup.sh` there) to fetch ERPNext and rebuild `codex.json`.
+5. The CI workflow in this repo executes the same script on each push.
+6. Place reference payloads or API docs in `sample_data/`.
 
 ## Repository Layout
 
@@ -16,6 +17,7 @@ This repository acts as a template for ERPNext extensions and is usually combine
 - `instructions/` – ERPNext development notes.
 - `sample_data/` – example payloads and docs.
 - `template-repos.txt` – list of additional templates.
+- `apps.json` – ERPNext repository and tag.
 
 ## Testing
 

--- a/erpnext_app_template/README.md
+++ b/erpnext_app_template/README.md
@@ -6,10 +6,10 @@
 
 1. **Clone this repo** or include it as a submodule of your Frappe based project.
 2. **Optional template repos** go into `template-repos.txt`.
-3. The file `vendor-repos.txt` lists required framework apps. It already
-   includes ERPNext so the Frappe template clones it automatically.
-4. **Sample data** can be placed in `sample_data/`.
-5. **Commit and push** your customised repository.
+3. The file `apps.json` pins the ERPNext version to clone as a submodule.
+4. `vendor-repos.txt` lists additional framework apps if needed.
+5. **Sample data** can be placed in `sample_data/`.
+6. **Commit and push** your customised repository.
 
 Trigger the **Update Vendor Apps** workflow in the Frappe template (or run `./setup.sh` there) to clone ERPNext and generate `codex.json`. Afterwards create a Codex environment and start developing your extensions.
 
@@ -24,6 +24,8 @@ codex.json          # Index of sources for Codex
 codex_prompt.md     # Main prompt for Codex
 setup.sh            # Initialization script
 template-repos.txt  # Additional templates
+apps.json           # ERPNext repository and tag
+vendor-repos.txt    # Further framework apps
 sample_data/        # Example payloads and API docs
 ```
 

--- a/erpnext_app_template/apps.json
+++ b/erpnext_app_template/apps.json
@@ -1,0 +1,6 @@
+{
+  "erpnext": {
+    "repo": "https://github.com/frappe/erpnext",
+    "tag": "v13.3.0"
+  }
+}

--- a/setup.sh
+++ b/setup.sh
@@ -55,6 +55,19 @@ if [ -f apps.json ]; then
     done
 fi
 
+# additional apps.json files from templates
+find vendor -maxdepth 2 -name apps.json | while read file; do
+    jq -r 'to_entries[] | "\(.key) \(.value.repo) \(.value.tag)"' "$file" | while read name repo tag; do
+        target="vendor/$name"
+        if [ ! -d "$target" ]; then
+            git submodule add "$repo" "$target"
+        fi
+        git -C "$target" fetch --tags
+        git -C "$target" checkout "$tag"
+        git add "$target"
+    done
+done
+
 # eigentliche vendor-Repos klonen
 if [ -f vendor-repos.txt ]; then
     while IFS= read -r line; do


### PR DESCRIPTION
## Summary
- update README with instructions about `apps.json` files in templates
- note template `apps.json` support in developer instructions
- add ERPNext version example under `erpnext_app_template/apps.json`
- document `apps.json` usage in ERPNext template docs
- allow `setup.sh` to process apps.json from template repos
- watch for `apps.json` files in vendor update workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68580409b3a483219e9a5d5ac92c464d