### PR TITLE
Improve template docs for submodule usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ sites/*/public/
 
 # Logs
 *.log
+
+# Keep configuration files under version control
+!apps.json
+!vendor-repos.txt
+!template-repos.txt

--- a/README.md
+++ b/README.md
@@ -48,6 +48,34 @@ This repository is a starting point for developing custom **Frappe** application
 7. Place any example payloads or external API docs under `sample_data/` for
    reference. The directory is indexed in `codex.json` when present.
 
+## Using this Template as a Submodule
+
+You can also start a new project by including this repository as a Git submodule.
+This keeps the base template separate so you can pull in updates later.
+
+```bash
+git init myapp
+cd myapp
+git submodule add https://github.com/seclution/frappe_app_template template
+```
+
+Copy `apps.json`, `vendor-repos.txt` and `template-repos.txt` from `template/`
+to your project root and adjust them as needed. Run the setup script inside the
+submodule to clone the vendor apps and generate `codex.json`:
+
+```bash
+cd template
+./setup.sh
+```
+
+To update the template later simply execute:
+
+```bash
+git submodule update --remote template
+git commit -am "chore: update base template"
+```
+
+
 ## Adding Vendor Apps
 
 Use `git submodule add <repo> vendor/<name>` to include further Frappe apps.

--- a/instructions/README.md
+++ b/instructions/README.md
@@ -21,3 +21,4 @@ Refer to the following guides for framework-specific tips:
 
 - [Frappe Notes](./frappe.md)
 - [ERPNext Notes](./erpnext.md)
+- [Using the Template as a Submodule](./submodule_usage.md)

--- a/instructions/submodule_usage.md
+++ b/instructions/submodule_usage.md
@@ -1,0 +1,46 @@
+# Using the Frappe Template as a Submodule
+
+This guide explains how to start a new repository that keeps the `frappe_app_template` as a Git submodule. The approach allows you to pull in updates from the template at any time.
+
+## 1. Repository Setup
+
+```bash
+mkdir myapp
+cd myapp
+git init
+# add the template as submodule
+git submodule add https://github.com/seclution/frappe_app_template template
+```
+
+Copy the configuration files from the template so you can adjust them:
+
+```bash
+cp template/apps.json .
+cp template/vendor-repos.txt .
+cp template/template-repos.txt . # optional
+```
+
+Edit these files to add your own vendor apps or additional templates.
+
+## 2. Initialising the Environment
+
+Run the setup script inside the submodule to clone the vendor apps and generate `codex.json`:
+
+```bash
+cd template
+./setup.sh
+cd ..
+```
+
+Commit all generated files and push the repository to GitHub. Trigger the *Update Vendor Apps* workflow if you want to rebuild `codex.json` automatically.
+
+## 3. Updating the Template
+
+Whenever a new version of the template is available, update the submodule:
+
+```bash
+git submodule update --remote template
+git commit -am "chore: update template"
+```
+
+This pulls the latest changes from `frappe_app_template` while keeping your own configuration files intact.


### PR DESCRIPTION
## Summary
- document how to use the template as a submodule
- link from instructions to the new guide
- keep config files tracked via `.gitignore`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685807e00bd8832198bb01e4b63d601c